### PR TITLE
Add c99 explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ C_INCLUDES =  \
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fno-common -fdata-sections -ffunction-sections
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wpedantic -Wextra -fno-common -fdata-sections -ffunction-sections $(BOARD_FLAGS)
+CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wpedantic -Wextra -fno-common -fdata-sections -ffunction-sections -std=c99 $(BOARD_FLAGS)
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2


### PR DESCRIPTION
Default make in linux is ISO 90, ```Src/pcan_usb.c:108:3: error: 'for' loop initial declarations are only allowed in C99 or C11 mode``` will be raised.

Adding c99 explicitly sovles this issue